### PR TITLE
The setting page is functional and can change email/pass, method of logging out changed slightly

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -12,8 +12,8 @@
     -->
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
-    crossorigin="anonymous">
+  <!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+    crossorigin="anonymous"> -->
   <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/client/src/components/CSS/settings.css
+++ b/client/src/components/CSS/settings.css
@@ -1,6 +1,6 @@
 .Settings {
-  /* display: flex;
-  justify-content: center; */
+  display: flex;
+  justify-content: center;
   /* min-height: 100vh;
   background-image: url(Buildings.jpg);
   background-repeat: no-repeat;
@@ -11,6 +11,8 @@
 
 .Settings form {
   align-self: center;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .Settings form .form-group {
@@ -21,6 +23,8 @@
 }
 
 .Settings form .form-group .control-label {
+  display: flex;
+  flex-wrap: wrap;
   margin: 0;
 }
 

--- a/client/src/components/CSS/settings.css
+++ b/client/src/components/CSS/settings.css
@@ -1,0 +1,49 @@
+.Settings {
+  /* display: flex;
+  justify-content: center; */
+  /* min-height: 100vh;
+  background-image: url(Buildings.jpg);
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: center;
+  background-size: cover; */
+}
+
+.Settings form {
+  align-self: center;
+}
+
+.Settings form .form-group {
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 20rem;
+  justify-content: center;
+}
+
+.Settings form .form-group .control-label {
+  margin: 0;
+}
+
+.Settings form .form-group .help-block {
+  margin: 0;
+}
+
+.Settings form .btn {
+  margin-top: 2rem;
+}
+
+.Settings .modal {
+  position: absolute;
+  /* the top and bottom make the modal relatively
+  centered on the screen */
+  top: 25%;
+  bottom: 10%;
+}
+
+.Settings .modal-footer {
+  justify-content: center;
+}
+
+.Settings .btn {
+  /* font-size: 1.6rem; */
+}

--- a/client/src/components/login.js
+++ b/client/src/components/login.js
@@ -21,7 +21,7 @@ const urls = require("../config.json");
 export default class Login extends Component {
   constructor(props) {
     super(props);
-    this.state = scrinch;
+    this.state = bobbert;
   }
 
   validateForm() {

--- a/client/src/components/login.js
+++ b/client/src/components/login.js
@@ -22,8 +22,7 @@ const urls = require("../config.json");
 export default class Login extends Component {
   constructor(props) {
     super(props);
-
-    this.state = bobbert;
+    this.state = scrinch;
   }
 
   validateForm() {

--- a/client/src/components/login.js
+++ b/client/src/components/login.js
@@ -5,8 +5,7 @@ import axios from "axios";
 
 const scrinch = {
   email: "scrinch@gmail.com",
-  password:
-    "YjBjZDYyM2Y1MGY4YTY2ZDFjYzBhZTMzMTJiZjhlZTMxMzc3Nzg5OThlOWMzZjU5NTgxNDYyMWI3ODQ5ODc0OQ!",
+  password: "tacobell1!G1",
   invalidCredentials: false
 };
 

--- a/client/src/components/settings.js
+++ b/client/src/components/settings.js
@@ -233,7 +233,7 @@ export class PersonalInfo extends Component {
             <FormGroup controlId="phonenumber" bsSize="large">
               <ControlLabel>Phone Number</ControlLabel>
               <FormControl
-                value={this.state.name.lastname}
+                value={this.state.phonenumber}
                 onChange={this.handleChange}
               />
             </FormGroup>
@@ -265,7 +265,6 @@ export class PersonalInfo extends Component {
                 onChange={this.handleChange}
               />
             </FormGroup>
-
             <FormGroup
               controlId="email"
               bsSize="large"
@@ -281,7 +280,6 @@ export class PersonalInfo extends Component {
                 <HelpBlock>Please enter an unused valid email.</HelpBlock>
               ) : null}
             </FormGroup>
-
             <FormGroup
               controlId="oldpassword"
               bsSize="large"

--- a/client/src/components/settings.js
+++ b/client/src/components/settings.js
@@ -25,7 +25,7 @@ export class PersonalInfo extends Component {
         lastname: ""
       },
       location: "",
-      title: "",
+      // title: "",
       phonenumber: "",
       links: {
         linkedin: "",

--- a/client/src/components/settings.js
+++ b/client/src/components/settings.js
@@ -205,141 +205,147 @@ export class PersonalInfo extends Component {
       this.props.context.userInfo
     );
     return (
-      <div className="Settings">
+      <div>
         <h1> Personal Information </h1>
-        <form>
-          <FormGroup controlId="name.firstname" bsSize="large">
-            <ControlLabel>First Name</ControlLabel>
-            <FormControl
-              value={this.state.name.firstname}
-              onChange={this.handleChange}
-            />
-          </FormGroup>
-          <FormGroup controlId="name.middlename" bsSize="large">
-            <ControlLabel>Middle Name</ControlLabel>
-            <FormControl
-              value={this.state.name.middlename}
-              onChange={this.handleChange}
-            />
-          </FormGroup>
-          <FormGroup controlId="name.lastname" bsSize="large">
-            <ControlLabel>Last Name</ControlLabel>
-            <FormControl
-              value={this.state.name.lastname}
-              onChange={this.handleChange}
-            />
-          </FormGroup>
-          <FormGroup controlId="phonenumber" bsSize="large">
-            <ControlLabel>Phone Number</ControlLabel>
-            <FormControl
-              value={this.state.name.lastname}
-              onChange={this.handleChange}
-            />
-          </FormGroup>
-          <FormGroup controlId="location" bsSize="large">
-            <ControlLabel>Location</ControlLabel>
-            <FormControl
-              value={this.state.location}
-              onChange={this.handleChange}
-            />
-          </FormGroup>
-          <FormGroup controlId="links.linkedin" bsSize="large">
-            <ControlLabel>Linkedin</ControlLabel>
-            <FormControl
-              value={this.state.links.linkedin}
-              onChange={this.handleChange}
-            />
-          </FormGroup>
-          <FormGroup controlId="links.github" bsSize="large">
-            <ControlLabel>Github</ControlLabel>
-            <FormControl
-              value={this.state.links.github}
-              onChange={this.handleChange}
-            />
-          </FormGroup>
-          <FormGroup controlId="links.portfolio" bsSize="large">
-            <ControlLabel>Portfolio</ControlLabel>
-            <FormControl
-              value={this.state.links.portfolio}
-              onChange={this.handleChange}
-            />
-          </FormGroup>
+        <div className="Settings">
+          <form>
+            <FormGroup controlId="name.firstname" bsSize="large">
+              <ControlLabel>First Name</ControlLabel>
+              <FormControl
+                value={this.state.name.firstname}
+                onChange={this.handleChange}
+              />
+            </FormGroup>
+            <FormGroup controlId="name.middlename" bsSize="large">
+              <ControlLabel>Middle Name</ControlLabel>
+              <FormControl
+                value={this.state.name.middlename}
+                onChange={this.handleChange}
+              />
+            </FormGroup>
+            <FormGroup controlId="name.lastname" bsSize="large">
+              <ControlLabel>Last Name</ControlLabel>
+              <FormControl
+                value={this.state.name.lastname}
+                onChange={this.handleChange}
+              />
+            </FormGroup>
+            <FormGroup controlId="phonenumber" bsSize="large">
+              <ControlLabel>Phone Number</ControlLabel>
+              <FormControl
+                value={this.state.name.lastname}
+                onChange={this.handleChange}
+              />
+            </FormGroup>
+            <FormGroup controlId="location" bsSize="large">
+              <ControlLabel>Location</ControlLabel>
+              <FormControl
+                value={this.state.location}
+                onChange={this.handleChange}
+              />
+            </FormGroup>
+            <FormGroup controlId="links.linkedin" bsSize="large">
+              <ControlLabel>Linkedin</ControlLabel>
+              <FormControl
+                value={this.state.links.linkedin}
+                onChange={this.handleChange}
+              />
+            </FormGroup>
+            <FormGroup controlId="links.github" bsSize="large">
+              <ControlLabel>Github</ControlLabel>
+              <FormControl
+                value={this.state.links.github}
+                onChange={this.handleChange}
+              />
+            </FormGroup>
+            <FormGroup controlId="links.portfolio" bsSize="large">
+              <ControlLabel>Portfolio</ControlLabel>
+              <FormControl
+                value={this.state.links.portfolio}
+                onChange={this.handleChange}
+              />
+            </FormGroup>
 
-          <FormGroup
-            controlId="email"
-            bsSize="large"
-            validationState={this.state.emailInvalid}
-          >
-            <ControlLabel>Email</ControlLabel>
-            <FormControl
-              type="email"
-              value={this.state.email}
-              onChange={this.handleChange}
-            />
-            {this.state.emailInvalid ? (
-              <HelpBlock>Please enter an unused valid email.</HelpBlock>
-            ) : null}
-          </FormGroup>
+            <FormGroup
+              controlId="email"
+              bsSize="large"
+              validationState={this.state.emailInvalid}
+            >
+              <ControlLabel>Email</ControlLabel>
+              <FormControl
+                type="email"
+                value={this.state.email}
+                onChange={this.handleChange}
+              />
+              {this.state.emailInvalid ? (
+                <HelpBlock>Please enter an unused valid email.</HelpBlock>
+              ) : null}
+            </FormGroup>
 
-          <FormGroup
-            controlId="oldpassword"
-            bsSize="large"
-            validationState={this.checkPasswordStrength(this.state.oldpassword)}
-          >
-            <ControlLabel>Current Password</ControlLabel>
-            <FormControl
-              type="password"
-              value={this.state.oldpassword}
-              onChange={this.handleChange}
-            />
-            {this.state.passwordInvalid ? (
-              <HelpBlock>
-                Incorrect password. Please enter your current password if you
-                want to make a new password or change your email.
-              </HelpBlock>
-            ) : null}
-          </FormGroup>
-          <FormGroup
-            controlId="newpassword"
-            bsSize="large"
-            validationState={this.checkPasswordStrength(this.state.newpassword)}
-          >
-            <ControlLabel>New Password</ControlLabel>
-            <FormControl
-              type="password"
-              value={this.state.newpassword}
-              onChange={this.handleChange}
-            />
-            {this.checkPasswordStrength(this.state.newpassword) ? (
-              <HelpBlock>
-                Please use a complex password at least 8 characters long.
-              </HelpBlock>
-            ) : null}
-          </FormGroup>
-          <FormGroup
-            controlId="newconfirmpassword"
-            bsSize="large"
-            validationState={this.checkConfirmPassword()}
-          >
-            <ControlLabel>Confirm New Password</ControlLabel>
-            <FormControl
-              type="password"
-              value={this.state.newconfirmpassword}
-              onChange={this.handleChange}
-            />
-            {this.state.newconfirmpassword !== this.state.newpassword ? (
-              <HelpBlock>Please make this match your new password.</HelpBlock>
-            ) : null}
-          </FormGroup>
-        </form>
-        <Button
-          block
-          bsSize="large"
-          bsStyle="primary"
-          onClick={() => this.checkInputValidity()}
-        >
-          Submit
-        </Button>
+            <FormGroup
+              controlId="oldpassword"
+              bsSize="large"
+              validationState={this.checkPasswordStrength(
+                this.state.oldpassword
+              )}
+            >
+              <ControlLabel>Current Password</ControlLabel>
+              <FormControl
+                type="password"
+                value={this.state.oldpassword}
+                onChange={this.handleChange}
+              />
+              {this.state.passwordInvalid ? (
+                <HelpBlock>
+                  Incorrect password. Please enter your current password if you
+                  want to make a new password or change your email.
+                </HelpBlock>
+              ) : null}
+            </FormGroup>
+            <FormGroup
+              controlId="newpassword"
+              bsSize="large"
+              validationState={this.checkPasswordStrength(
+                this.state.newpassword
+              )}
+            >
+              <ControlLabel>New Password</ControlLabel>
+              <FormControl
+                type="password"
+                value={this.state.newpassword}
+                onChange={this.handleChange}
+              />
+              {this.checkPasswordStrength(this.state.newpassword) ? (
+                <HelpBlock>
+                  Please use a complex password at least 8 characters long.
+                </HelpBlock>
+              ) : null}
+            </FormGroup>
+            <FormGroup
+              controlId="newconfirmpassword"
+              bsSize="large"
+              validationState={this.checkConfirmPassword()}
+            >
+              <ControlLabel>Confirm New Password</ControlLabel>
+              <FormControl
+                type="password"
+                value={this.state.newconfirmpassword}
+                onChange={this.handleChange}
+              />
+              {this.state.newconfirmpassword !== this.state.newpassword ? (
+                <HelpBlock>Please make this match your new password.</HelpBlock>
+              ) : null}
+            </FormGroup>
+            <Button
+              block
+              bsSize="large"
+              bsStyle="primary"
+              onClick={() => this.checkInputValidity()}
+            >
+              Submit
+            </Button>
+          </form>
+        </div>
       </div>
     );
   }

--- a/client/src/components/subComponents/navbar.js
+++ b/client/src/components/subComponents/navbar.js
@@ -21,8 +21,7 @@ class Navbar extends Component {
               type="button"
               className="btn btn-light"
               onClick={() => {
-                this.props.context.actions.setValue("auth", false);
-                localStorage.removeItem("token");
+                this.props.context.actions.setLogout();
                 history.push("/");
               }}
             >

--- a/client/src/components/subComponents/sidebar.js
+++ b/client/src/components/subComponents/sidebar.js
@@ -14,7 +14,7 @@ class Sidebar extends Component {
 
   componentDidMount() {
     if (
-      this.props.context.userInfo.auth !== true &&
+      // this.props.context.userInfo.auth !== true &&
       localStorage.getItem("token")
     ) {
       console.log("passed token check");
@@ -30,7 +30,7 @@ class Sidebar extends Component {
         })
         .catch(err => {
           console.log("err", err);
-          localStorage.removeItem("token");
+          this.props.context.actions.setLogout();
         });
     }
   }

--- a/client/src/config.json
+++ b/client/src/config.json
@@ -2,5 +2,5 @@
   "localPath": "http://localhost:3333",
   "herokuPath": "https://easy-resume.herokuapp.com",
   "altHerokuPath": "https://rez-me.herokuapp.com",
-  "basePath": "localPath"
+  "basePath": "herokuPath"
 }

--- a/client/src/config.json
+++ b/client/src/config.json
@@ -2,5 +2,5 @@
   "localPath": "http://localhost:3333",
   "herokuPath": "https://easy-resume.herokuapp.com",
   "altHerokuPath": "https://rez-me.herokuapp.com",
-  "basePath": "herokuPath"
+  "basePath": "localPath"
 }

--- a/client/src/contexts/AuthProvider.js
+++ b/client/src/contexts/AuthProvider.js
@@ -38,7 +38,7 @@ class AuthProvider extends Component {
 
         lastname: userData.name.lastname ? userData.name.lastname : ""
       },
-      title: userData.title ? userData.title : "",
+      title: userData.title ? userData.title : [],
       links: userData.links ? userData.links : [],
       location: userData.location ? userData.location : "",
       phonenumber: userData.phonenumber ? userData.phonenumber : "",

--- a/client/src/contexts/AuthProvider.js
+++ b/client/src/contexts/AuthProvider.js
@@ -20,12 +20,34 @@ class AuthProvider extends Component {
     summary: []
   };
 
-  toggleAuth = () => {
-    this.setState({ auth: !this.state.auth });
-  };
+  // Use setLogout instead of this
+  // toggleAuth = () => {
+  //   this.setState({ auth: !this.state.auth });
+  // };
 
   setValue = (title, value) => {
     this.setState({ [title]: value });
+  };
+
+  setLogout = () => {
+    localStorage.removeItem("token");
+    this.setState({
+      auth: false,
+      username: "",
+      email: "",
+      name: {
+        firstname: "",
+        middlename: "",
+        lastname: ""
+      },
+      title: "",
+      phonenumber: "",
+      links: [],
+      education: [],
+      experience: [],
+      skills: [],
+      summary: []
+    });
   };
 
   setLogin = userData => {
@@ -75,6 +97,7 @@ class AuthProvider extends Component {
             toggleAuth: this.toggleAuth,
             setValue: this.setValue,
             setLogin: this.setLogin,
+            setLogout: this.setLogout,
             setElement: this.setElement,
             addElement: this.addElement
           }

--- a/client/src/contexts/AuthProvider.js
+++ b/client/src/contexts/AuthProvider.js
@@ -20,15 +20,6 @@ class AuthProvider extends Component {
     summary: []
   };
 
-  // Use setLogout instead of this
-  // toggleAuth = () => {
-  //   this.setState({ auth: !this.state.auth });
-  // };
-
-  setValue = (title, value) => {
-    this.setState({ [title]: value });
-  };
-
   setLogout = () => {
     localStorage.removeItem("token");
     this.setState({
@@ -95,7 +86,6 @@ class AuthProvider extends Component {
           userInfo,
           actions: {
             toggleAuth: this.toggleAuth,
-            setValue: this.setValue,
             setLogin: this.setLogin,
             setLogout: this.setLogout,
             setElement: this.setElement,

--- a/user/UserModel.js
+++ b/user/UserModel.js
@@ -14,10 +14,10 @@ const validateEmail = email => {
 /*
   Phone Number example: 123-456-7890
 */
-const validatePhone = number => {
-  const re = /^([0-9]{3}-)([0-9]{3}-)([0-9]{4})$/g;
-  return re.test(number);
-};
+// const validatePhone = number => {
+//   const re = /^([0-9]{3}-)([0-9]{3}-)([0-9]{4})$/g;
+//   return re.test(number);
+// };
 
 /* 
   Password Requirements:
@@ -39,21 +39,23 @@ const checkPasswordStrength = password => {
   return true;
 };
 
+// Checking links on the backend is a waste of processing time and creates unnecessary validation errors
+
 /*
   Linkedin example: linkedin.com/in/test/ (allows some special characters)
 */
-const validateLinkedIn = url => {
-  const re = /^(linkedin\.com\/in\/[\w-!@#$%^&*]+)$/;
-  return re.test(url);
-};
+// const validateLinkedIn = url => {
+//   const re = /^(linkedin\.com\/in\/[\w-!@#$%^&*]+)$/;
+//   return re.test(url);
+// };
 
 /*
   GitHub example: github.com/test/ (allows some special characters)
 */
-const validateGithub = url => {
-  const re = /^(github\.com\/[\w-!@#$%^&*]+)$/;
-  return re.test(url);
-};
+// const validateGithub = url => {
+//   const re = /^(github\.com\/[\w-!@#$%^&*]+)$/;
+//   return re.test(url);
+// };
 
 const User = new mongoose.Schema(
   {
@@ -107,17 +109,17 @@ const User = new mongoose.Schema(
       }
     ],
     phonenumber: {
-      type: String,
-      validate: [validatePhone, "Invalid Phone Number"]
+      type: String
+      // validate: [validatePhone, "Invalid Phone Number"]
     },
     links: {
       linkedin: {
-        type: String,
-        validate: [validateLinkedIn, "Invalid Linkedin"]
+        type: String
+        // validate: [validateLinkedIn, "Invalid Linkedin"]
       },
       github: {
-        type: String,
-        validate: [validateGithub, "Invalid GitHub"]
+        type: String
+        // validate: [validateGithub, "Invalid GitHub"]
       },
       portfolio: String
     },
@@ -131,16 +133,16 @@ const User = new mongoose.Schema(
         {
           title: {
             type: String,
-            required: true
+            default: "title"
           },
           company: {
             type: String,
-            required: true
+            default: ""
           },
           location: String,
           from: {
             type: String,
-            required: true
+            default: ""
           },
           to: String,
           description: String
@@ -150,19 +152,19 @@ const User = new mongoose.Schema(
         {
           school: {
             type: String,
-            required: true
+            default: "school"
           },
           degree: {
             type: String,
-            required: true
+            default: ""
           },
           fieldofstudy: {
             type: String,
-            required: true
+            default: ""
           },
           from: {
             type: String,
-            required: true
+            default: ""
           },
           to: String
         }

--- a/user/UserRoutes.js
+++ b/user/UserRoutes.js
@@ -421,7 +421,7 @@ UserRouter.put(
                         });
                       // ======
                     }
-                    if (req.body.newpassword) {
+                    if (req.body.newpassword && req.body.newpassword != "") {
                       user.password = req.body.newpassword;
                       user.save(function(err) {
                         if (err) {


### PR DESCRIPTION
# Description

The setting page is functional and can change email/pass, method of logging out changed slightly. I made a setLogout function for logging out on the authprovider that deletes the token and sets auth to false, and got rid of the extraneous setValue and toggleAuth functions that were in that file. I also made all the required: true on the user model for things like education/experience to false and set the defaults to "" instead because otherwise there would be validation errors when trying to change password if anything a user had in those fields was "". I also removed backend validation for githubs and linkedin because its unnecessary and can be done on the frontend if needed.

I also added the beginnings of a generic item card that will be able to display anything that needs a card like summaries or education.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Changing pass/email works in settings
- [x] Logging out works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
